### PR TITLE
remove dependencies from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,20 +4,6 @@ setup(
     name="pre_prepare_receptor",
     version="0.1.0",
     py_modules=["pre_prepare_receptor"],
-    install_requires=[
-        "numpy",
-        "requests",
-        "prody",
-        "rdkit-pypi",
-        "openmm",
-        "openff-toolkit",
-        "pdbfixer",
-        "parmed",
-        "autopath",
-        "mdanalysis",
-        "deeptime",
-        "pyemma"
-    ],
     entry_points={
         "console_scripts": [
             "pre_prepare_receptor=pre_prepare_receptor:main",


### PR DESCRIPTION
on my end pip tried to update prody to 2.6, which tried to update to numpy 2, and that failed. Had already installed prody 2.4 from conda-forge. The approach in this PR, also followed in e.g., meeko, is to delegate all dependency mangament to the user or to conda-forge recipes, and remove all dependencies from setup.py